### PR TITLE
feat(settings): Add grow_start_date + Day N + Grow quick-range + Sensors header badge

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -50,6 +50,7 @@ DEFAULTS: Dict[str, str] = {
     "general.grow_name": "RDWC v4",
     "general.timezone": "Africa/Johannesburg",
     "general.reservoir_liters": "25",
+    "general.grow_start_date": "",  # YYYY-MM-DD or empty string
 
     # targets
     "targets.ph_low": "5.8",
@@ -196,6 +197,28 @@ def validate_partial(partial: Dict[str, Any]) -> Tuple[bool, Optional[Dict[str, 
         v = f(final["general.reservoir_liters"])
         if v is None or not (1 <= v <= 1000):
             return False, {"field": "general.reservoir_liters", "message": "Must be 1–1000"}
+
+    # Grow start date (YYYY-MM-DD or empty)
+    if "general.grow_start_date" in final:
+        val = str(final["general.grow_start_date"]).strip()
+        if val:
+            # Validate format
+            if not re.match(r'^\d{4}-\d{2}-\d{2}$', val):
+                return False, {"field": "general.grow_start_date", "message": "Must be YYYY-MM-DD or empty"}
+            # Check it's a real date and not in the future
+            try:
+                date_obj = datetime.strptime(val, "%Y-%m-%d").date()
+                # Get timezone from settings
+                tz_str = final.get("general.timezone", "Africa/Johannesburg")
+                try:
+                    tz = pytz.timezone(tz_str)
+                except Exception:
+                    tz = SA_TZ
+                today = datetime.now(tz).date()
+                if date_obj > today:
+                    return False, {"field": "general.grow_start_date", "message": "date_in_future"}
+            except ValueError:
+                return False, {"field": "general.grow_start_date", "message": "Invalid date"}
 
     # Min on/off 0–3600 s
     for k in ("safety.main_pump_min_off_s", "safety.chiller_pump_min_off_s",

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -440,7 +440,10 @@ th,td{border-bottom:1px solid #1f2937;padding:6px 8px;text-align:left}
   <!-- Sensors Card with Chart.js -->
   <section id="sensors-card" class="card card-wide">
     <div class="card-header" style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;margin-bottom:12px;">
-      <div style="font-weight:600;">Sensors</div>
+      <div style="display:flex;align-items:center;gap:8px;">
+        <div style="font-weight:600;">Sensors</div>
+        <span id="sensors-grow-day-badge" style="display:none;padding:4px 8px;border-radius:6px;background:rgba(59,130,246,0.12);border:1px solid rgba(59,130,246,0.3);color:#93c5fd;font-size:0.85rem;font-weight:500;"></span>
+      </div>
       <div class="trend-controls" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
         <button class="btn btn-chip" data-range="24h">24h</button>
         <button class="btn btn-chip" data-range="7d">7d</button>

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -8,7 +8,8 @@
       fields: {
         'general.grow_name': {label:'Grow name', type:'text'},
         'general.timezone': {label:'Timezone', type:'text', placeholder:'Africa/Johannesburg'},
-        'general.reservoir_liters': {label:'Reservoir (L)', type:'number', min:1, max:1000, step:0.1}
+        'general.reservoir_liters': {label:'Reservoir (L)', type:'number', min:1, max:1000, step:0.1},
+        'general.grow_start_date': {label:'Grow start date', type:'date', tooltip:'Used for \'Grow\' quick range and Day N'}
       }
     },
     targets: {
@@ -99,6 +100,11 @@
         if (meta.placeholder) input.placeholder = meta.placeholder;
         input.value = val;
         input.style.cssText = 'margin-left:8px;padding:4px;border-radius:4px;border:1px solid #1f2937;background:#111827;color:#e6edf3;';
+        // For date inputs, set max to today
+        if (meta.type === 'date') {
+          const today = new Date().toISOString().split('T')[0];
+          input.max = today;
+        }
       }
       input.id = id;
       input.addEventListener('input', ()=>{
@@ -108,6 +114,10 @@
           current[key] = input.value;
         }
         markDirty();
+        // Update Day N badge if grow_start_date changed
+        if (key === 'general.grow_start_date') {
+          updateDayNBadge();
+        }
       });
       wrap.appendChild(label);
       wrap.appendChild(input);
@@ -118,6 +128,17 @@
         tip.textContent = meta.tooltip;
         wrap.appendChild(tip);
       }
+      
+      // Add Day N badge after grow_start_date input
+      if (key === 'general.grow_start_date') {
+        const badge = document.createElement('span');
+        badge.id = 'grow-day-n-badge';
+        badge.className = 'muted';
+        badge.style.cssText = 'margin-left:8px;padding:4px 8px;border-radius:6px;background:rgba(59,130,246,0.12);border:1px solid rgba(59,130,246,0.3);color:#93c5fd;font-size:0.85rem;';
+        badge.style.display = 'none';
+        wrap.appendChild(badge);
+      }
+      
       panel.appendChild(wrap);
     });
     return panel;
@@ -200,7 +221,59 @@
       if (uiRel) window.APP_POLL.relays = parseInt(uiRel,10)||1000;
       if (uiSen) window.APP_POLL.sensors = parseInt(uiSen,10)||5000;
       window.dispatchEvent(new CustomEvent('settings:ui', {detail:{poll: window.APP_POLL}}));
+      // Update Day N badge and Sensors header if grow_start_date changed
+      if (changes['general.grow_start_date'] !== undefined) {
+        updateDayNBadge();
+        updateSensorsHeaderDayN();
+      }
       markDirty();
+    }
+  }
+  
+  function updateDayNBadge() {
+    const badge = q('#grow-day-n-badge');
+    if (!badge) return;
+    const startDate = current['general.grow_start_date'];
+    if (!startDate) {
+      badge.style.display = 'none';
+      return;
+    }
+    const dayN = calculateDayN(startDate, current['general.timezone']);
+    if (dayN !== null) {
+      badge.textContent = `Day ${dayN}`;
+      badge.style.display = 'inline-block';
+    } else {
+      badge.style.display = 'none';
+    }
+  }
+  
+  function calculateDayN(startDateStr, timezone) {
+    if (!startDateStr) return null;
+    try {
+      const start = new Date(startDateStr + 'T00:00:00');
+      const now = new Date();
+      const diffMs = now - start;
+      const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+      return Math.max(1, diffDays + 1);
+    } catch (e) {
+      return null;
+    }
+  }
+  
+  function updateSensorsHeaderDayN() {
+    const startDate = current['general.grow_start_date'];
+    const badge = q('#sensors-grow-day-badge');
+    if (!badge) return;
+    if (!startDate) {
+      badge.style.display = 'none';
+      return;
+    }
+    const dayN = calculateDayN(startDate, current['general.timezone']);
+    if (dayN !== null) {
+      badge.textContent = `Grow Day ${dayN}`;
+      badge.style.display = 'inline-block';
+    } else {
+      badge.style.display = 'none';
     }
   }
 
@@ -245,6 +318,8 @@
       await fetchSettings();
       renderAll();
       bindTabs();
+      updateDayNBadge();
+      updateSensorsHeaderDayN();
       bindActions();
       markDirty();
       // seed APP_POLL from settings
@@ -256,6 +331,12 @@
       console.warn('settings boot failed', e);
     }
   }
+
+  // Expose helper for other modules
+  window.rdwcSettings = {
+    get: (key) => current[key] || '',
+    calculateDayN
+  };
 
   // Auto init once DOM is ready
   if (document.readyState === 'loading'){

--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -117,17 +117,33 @@
 
   async function loadGrow(){
     let startISO;
-    try {
-      const resp = await fetch('/api/grow/start');
-      if (!resp.ok) throw new Error('Grow start fetch failed');
-      const data = await resp.json();
-      startISO = data.start;
-    } catch(err){
-      console.error('Failed to fetch grow start:', err);
-      const fallback = new Date();
-      fallback.setDate(fallback.getDate() - 30);
-      startISO = fallback.toISOString();
+    // Try to get grow_start_date from settings
+    const growStartDate = window.rdwcSettings?.get('general.grow_start_date');
+    if (growStartDate) {
+      // Use grow start date at 00:00 local time
+      try {
+        const startDate = new Date(growStartDate + 'T00:00:00');
+        startISO = startDate.toISOString();
+      } catch(e) {
+        console.warn('Invalid grow_start_date format, using fallback:', e);
+      }
     }
+    
+    // Fallback to API or 30 days ago
+    if (!startISO) {
+      try {
+        const resp = await fetch('/api/grow/start');
+        if (!resp.ok) throw new Error('Grow start fetch failed');
+        const data = await resp.json();
+        startISO = data.start;
+      } catch(err){
+        console.error('Failed to fetch grow start:', err);
+        const fallback = new Date();
+        fallback.setDate(fallback.getDate() - 30);
+        startISO = fallback.toISOString();
+      }
+    }
+    
     const nowISO = new Date().toISOString();
     const startMs = new Date(startISO).getTime();
     const endMs = new Date(nowISO).getTime();


### PR DESCRIPTION
Adds grow_start_date to System Settings with validation and export/import, shows Day N in Settings and Sensors header, and hooks the Grow quick-range to the start date.

**Backend:**
- Seeded general.grow_start_date default (empty string)
- Validation: YYYY-MM-DD format, rejects future dates with 422 date_in_future
- Export/import includes the key with validation

**Frontend:**
- Settings  General: Date picker with Day N badge (updates live on save)
- Sensors header: Shows 'Grow Day N' chip when date is set
- Trends  Grow button: Auto-fills start = grow_start_date 00:00 local, end = now
- Max date constraint on picker (today)

**Testing:**
- PUT valid past date  updates and shows Day N
- PUT invalid format  422 with message
- PUT future date  422 date_in_future
- Export/import round-trip preserves key