### PR TITLE
feat(ph): Dose logging + totals + history chart

### DIFF
--- a/app/ph_control.py
+++ b/app/ph_control.py
@@ -42,6 +42,22 @@ def _ensure_tables() -> None:
             )
             """
         )
+        # Helpful index for time-ordered queries
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_ph_dose_log_ts ON ph_dose_log(ts_utc)")
+        # Optional daily totals view (idempotent)
+        try:
+            conn.execute(
+                """
+                CREATE VIEW IF NOT EXISTS ph_dose_daily AS
+                SELECT substr(ts_utc,1,10) AS day, SUM(COALESCE(volume_ml,0)) AS total_ml
+                FROM ph_dose_log
+                WHERE result='ok'
+                GROUP BY day
+                ORDER BY day ASC
+                """
+            )
+        except Exception:
+            pass
         conn.commit()
 
 def _log_row(row: Dict[str, Any]) -> int:
@@ -85,6 +101,58 @@ def _recent_doses(limit: int = 5) -> List[Dict[str, Any]]:
             "result": r[7], "reason": r[8]
         })
     return out
+
+def _dose_events_since(hours: int) -> List[Dict[str, Any]]:
+    _ensure_tables()
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=max(1, int(hours)))
+    with sqlite3.connect(str(DB_PATH)) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT ts_utc, action, volume_ml, duration_ms, pre_ph, post_ph, result, reason
+            FROM ph_dose_log
+            WHERE ts_utc >= ?
+            ORDER BY ts_utc ASC
+            """,
+            (cutoff.isoformat(),)
+        )
+        rows = cur.fetchall()
+    events = []
+    for r in rows:
+        duration_ms = r[3] if r[3] is not None else 0
+        seconds = round((duration_ms or 0)/1000.0, 3)
+        guard = r[7] if (r[6] == 'blocked' and r[7]) else None
+        events.append({
+            "ts": r[0],
+            "seconds": seconds,
+            "volume_ml": r[2],
+            "reason": r[1],  # action field maps to reason ('dose' with reason string below)
+            "ph_before": r[4],
+            "ph_after": r[5],
+            "guard_triggered": guard,
+            "result": r[6],
+            "action": r[1],
+            "detail": r[7]
+        })
+    return events
+
+def _dose_daily(days: int) -> List[Dict[str, Any]]:
+    _ensure_tables()
+    start_day = (datetime.now(timezone.utc) - timedelta(days=max(1, int(days))-1)).date().isoformat()
+    with sqlite3.connect(str(DB_PATH)) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT substr(ts_utc,1,10) AS day, SUM(COALESCE(volume_ml,0)) AS total_ml
+            FROM ph_dose_log
+            WHERE result='ok' AND substr(ts_utc,1,10) >= ?
+            GROUP BY day
+            ORDER BY day ASC
+            """,
+            (start_day,)
+        )
+        rows = cur.fetchall()
+    return [{"day": r[0], "total_ml": float(r[1] or 0.0)} for r in rows]
 
 def _today_total_ml(now_dt: datetime) -> float:
     _ensure_tables()
@@ -349,6 +417,50 @@ def ph_export(hours: int = Query(24)):
         line = ",".join([
             str(r[0]), str(r[1]), str(r[2] if r[2] is not None else ""), str(r[3] if r[3] is not None else ""),
             str(r[4] if r[4] is not None else ""), str(r[5] if r[5] is not None else ""), str(r[6]), str(r[7] if r[7] else "")
+        ])
+        lines.append(line)
+    return PlainTextResponse("\n".join(lines), media_type="text/csv")
+
+
+# --- New telemetry endpoints -------------------------------------------------
+@router.get("/api/ph/dose_log")
+def ph_dose_log(hours: int = Query(24)):
+    events = _dose_events_since(max(1, int(hours)))
+    # Align field names with spec
+    out = []
+    for e in events:
+        out.append({
+            "ts": e["ts"],
+            "seconds": e["seconds"],
+            "volume_ml": e["volume_ml"],
+            "reason": e.get("detail") or e.get("action") or "manual",
+            "ph_before": e["ph_before"],
+            "ph_after": e["ph_after"],
+            "guard_triggered": e["guard_triggered"],
+            "result": e["result"],
+        })
+    return out
+
+
+@router.get("/api/ph/dose_summary")
+def ph_dose_summary(days: int = Query(7)):
+    days = max(1, int(days))
+    rows = _dose_daily(days)
+    return rows
+
+
+@router.get("/api/ph/dose_log.csv")
+def ph_dose_log_csv(hours: int = Query(168)):
+    events = _dose_events_since(max(1, int(hours)))
+    lines = ["ts,seconds,volume_ml,reason,ph_before,ph_after,guard_triggered"]
+    for e in events:
+        line = ",".join([
+            str(e["ts"]), str(e["seconds"]),
+            "" if e["volume_ml"] is None else str(e["volume_ml"]),
+            str(e.get("detail") or e.get("action") or "manual"),
+            "" if e["ph_before"] is None else str(e["ph_before"]),
+            "" if e["ph_after"] is None else str(e["ph_after"]),
+            "" if not e["guard_triggered"] else str(e["guard_triggered"]) 
         ])
         lines.append(line)
     return PlainTextResponse("\n".join(lines), media_type="text/csv")

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -524,6 +524,13 @@ th,td{border-bottom:1px solid #1f2937;padding:6px 8px;text-align:left}
             <span id="ph-countdown-pill" class="countdown-pill" style="display:none;">⏱ 0s</span>
           </div>
 
+          <!-- Summary pills -->
+          <div id="ph-summary" style="display:flex;gap:10px;flex-wrap:wrap;margin:6px 0 12px 0;">
+            <span id="ph-total-today" class="muted" style="padding:4px 8px;border-radius:6px;background:rgba(34,197,94,0.12);border:1px solid rgba(34,197,94,0.3);color:#a7f3d0;">Today: — ml</span>
+            <span id="ph-total-week" class="muted" style="padding:4px 8px;border-radius:6px;background:rgba(59,130,246,0.12);border:1px solid rgba(59,130,246,0.3);color:#93c5fd;">Week: — ml</span>
+            <button id="ph-dose-csv" class="btn-secondary" title="Download dose log CSV (7d)">Download CSV</button>
+          </div>
+
           <div class="tabs" style="display:flex;gap:10px;flex-wrap:wrap;margin:8px 0 12px 0;">
             <button class="btn-secondary" onclick="document.getElementById('ph-tab-status').style.display='block';document.getElementById('ph-tab-manual').style.display='none';document.getElementById('ph-tab-auto').style.display='none';">Status</button>
             <button class="btn-secondary" onclick="document.getElementById('ph-tab-status').style.display='none';document.getElementById('ph-tab-manual').style.display='block';document.getElementById('ph-tab-auto').style.display='none';">Manual</button>
@@ -538,6 +545,7 @@ th,td{border-bottom:1px solid #1f2937;padding:6px 8px;text-align:left}
               </div>
             </div>
             <div id="ph-recent" class="muted"></div>
+            <div id="ph-calib-banner" class="muted" style="display:none;margin-top:8px;padding:6px 10px;border-radius:8px;background:rgba(148,163,184,0.08);border:1px solid rgba(148,163,184,0.3);color:#cbd5e1;">Set <strong>pH Up ml/s</strong> in Settings → Dosing to enable volume totals.</div>
           </div>
           <div id="ph-tab-manual" style="display:none;">
             <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center;">
@@ -552,6 +560,17 @@ th,td{border-bottom:1px solid #1f2937;padding:6px 8px;text-align:left}
             <div class="muted" style="margin-bottom:8px;">Automation placeholder</div>
             <button id="btnAutoToggle" class="btn-secondary">Enable automation</button>
           </div>
+
+          <!-- History chart -->
+          <hr class="separator" />
+          <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:6px;">
+            <div class="muted">Dose History</div>
+            <div style="display:flex;gap:6px;align-items:center;">
+              <button class="btn btn-chip" id="ph-chart-24h">24h</button>
+              <button class="btn btn-chip" id="ph-chart-7d">7d</button>
+            </div>
+          </div>
+          <canvas id="phDoseChart" height="120"></canvas>
         </div>
       </section>
 

--- a/app/static/js/ph.js
+++ b/app/static/js/ph.js
@@ -6,6 +6,7 @@
   let lastStatus = null;
   let countdownTimer = null;
   let lastPollAt = Date.now();
+  let chart, chartMode = '24h'; // '24h' | '7d'
 
   function el(id){ return document.getElementById(id); }
 
@@ -155,6 +156,11 @@
       else { alert(j.guard || 'Set'); }
     });
     el('btnPhExport24')?.addEventListener('click', ()=>{ window.open('/api/ph/export?hours=24','_blank'); });
+    el('ph-dose-csv')?.addEventListener('click', ()=>{ window.open('/api/ph/dose_log.csv?hours=168','_blank'); });
+
+    // Chart range buttons
+    el('ph-chart-24h')?.addEventListener('click', ()=>{ chartMode='24h'; refreshDoseChart(); });
+    el('ph-chart-7d')?.addEventListener('click', ()=>{ chartMode='7d'; refreshDoseChart(); });
 
     // listen for settings UI updates to ui.sensors_poll_ms
     window.addEventListener('settings:ui', (ev)=>{
@@ -167,5 +173,83 @@
     wire();
     tick();
     schedule();
+    refreshSummary();
+    refreshDoseChart();
   });
 })();
+  async function refreshSummary(){
+    try{
+      // Today: sum from 24h log; Week: 7d summary
+      const log = await (await fetch('/api/ph/dose_log?hours=24',{cache:'no-store'})).json();
+      const today = (log||[]).reduce((acc,e)=> acc + (e.volume_ml||0), 0);
+      const weekRows = await (await fetch('/api/ph/dose_summary?days=7',{cache:'no-store'})).json();
+      const week = (weekRows||[]).reduce((acc,r)=> acc + (r.total_ml||0), 0);
+      const tEl = el('ph-total-today'); if (tEl) tEl.textContent = `Today: ${today.toFixed(1)} ml`;
+      const wEl = el('ph-total-week'); if (wEl) wEl.textContent = `Week: ${week.toFixed(1)} ml`;
+      // Calibration banner if any volumes are null/undefined
+      const anyNull = (log||[]).some(e=> e.volume_ml==null);
+      const banner = el('ph-calib-banner'); if (banner) banner.style.display = anyNull ? 'block':'none';
+    }catch(e){ /* ignore */ }
+  }
+
+  function makeChart(){
+    const ctx = el('phDoseChart'); if (!ctx) return null;
+    const cfg = {
+      type:'bar',
+      data:{datasets:[]},
+      options:{
+        animation:false,
+        maintainAspectRatio:true,
+        parsing:false,
+        normalized:true,
+        scales:{
+          x:{type:'time', time:{tooltipFormat:'yyyy-MM-dd HH:mm', displayFormats:{hour:'MMM d HH:mm', day:'MMM d'}}},
+          y:{title:{display:true,text:'ml'}, beginAtZero:true}
+        },
+        plugins:{legend:{display:true}, tooltip:{callbacks:{
+          label:(ctx)=>{
+            const d = ctx.raw || {};
+            if (d.kind==='dose'){
+              const vol = (d.volume_ml==null)? '—' : `${d.volume_ml} ml`;
+              const ph = (d.ph_before!=null || d.ph_after!=null) ? ` pH: ${d.ph_before??'—'} → ${d.ph_after??'—'}` : '';
+              return ` +${vol} (${d.seconds}s, ${d.reason||'manual'})${ph}`;
+            }
+            if (d.kind==='daily'){ return ` Total: ${d.y.toFixed(1)} ml`; }
+            return '';
+          }
+        }}}
+      }
+    };
+    return new Chart(ctx, cfg);
+  }
+
+  async function refreshDoseChart(){
+    try{
+      if (!chart) chart = makeChart();
+      if (!chart) return;
+      let doses = [];
+      let daily = [];
+      if (chartMode==='24h'){
+        doses = await (await fetch('/api/ph/dose_log?hours=24',{cache:'no-store'})).json();
+      } else {
+        doses = await (await fetch('/api/ph/dose_log?hours=168',{cache:'no-store'})).json();
+        daily = await (await fetch('/api/ph/dose_summary?days=7',{cache:'no-store'})).json();
+      }
+      // Build datasets
+      const dosePoints = (doses||[]).map(e=>({
+        x: new Date(e.ts), y: e.volume_ml==null ? 0 : e.volume_ml, kind:'dose',
+        volume_ml:e.volume_ml, seconds:e.seconds, reason:e.reason, ph_before:e.ph_before, ph_after:e.ph_after
+      }));
+      const dailyBars = (daily||[]).map(d=>({ x: new Date(d.day+'T00:00:00'), y: d.total_ml, kind:'daily' }));
+
+      // Configure datasets
+      const doseDs = { type:'scatter', label:'Doses', data: dosePoints, parsing:false,
+        backgroundColor:'rgba(59,130,246,0.9)', pointRadius:4, pointHoverRadius:6, showLine:false };
+      const dailyDs = { type:'bar', label:'Daily total', data: dailyBars, parsing:false,
+        backgroundColor:'rgba(34,197,94,0.35)', borderColor:'rgba(34,197,94,0.6)' };
+      chart.data.datasets = (chartMode==='24h') ? [doseDs] : [dailyDs, doseDs];
+      chart.update('none');
+    }catch(e){ /* ignore */ }
+    // Refresh summary alongside
+    refreshSummary().catch(()=>{});
+  }

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -30,7 +30,8 @@
         'dosing.pulse_ml_bloom': {label:'Bloom pulse (ml)', type:'number', min:0, max:1000, step:1},
         'dosing.max_ml_hour_': {label:'Max per hour (ml)', type:'number', min:0, max:5000, step:1},
         'dosing.max_ml_day_': {label:'Max per day (ml)', type:'number', min:0, max:20000, step:1},
-        'dosing.mix_delay_s': {label:'Mix delay (s)', type:'number', min:0, max:3600, step:1}
+        'dosing.mix_delay_s': {label:'Mix delay (s)', type:'number', min:0, max:3600, step:1},
+        'dosing.ph_up_ml_per_sec': {label:'pH Up calibration (ml/s)', type:'number', min:0.1, max:200, step:0.1, tooltip:'Used to convert seconds to ml for totals'}
       }
     },
     safety: {


### PR DESCRIPTION
Adds pH dose telemetry: JSON and CSV endpoints, Today/Week totals, and a Chart.js dose history with markers. Keeps relays active-low, safe on boot, and no regressions.\n\nBackend:\n- /api/ph/dose_log?hours\n- /api/ph/dose_summary?days\n- /api/ph/dose_log.csv?hours\n\nFrontend:\n- Summary pills (Today/Week) and CSV button\n- Mixed chart with 24h/7d toggle and per-dose markers\n\nSettings:\n- Expose dosing.ph_up_ml_per_sec calibration input