### PR TITLE
fix(ui): EC shows mS/cm with ppm @500 hint

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1034,8 +1034,11 @@ th,td{border-bottom:1px solid #1f2937;padding:6px 8px;text-align:left}
         <div class="kpi-value" id="kpiPh">—</div>
       </div>
       <div class="kpi kpi-ec">
-        <div class="kpi-label">EC (mS/cm)</div>
-        <div class="kpi-value" id="kpiEc">—</div>
+        <div class="kpi-label" title="Backend stores mS/cm. ppm shown @500 scale for convenience.">
+          EC (mS/cm)
+        </div>
+        <div class="kpi-value" id="kpiEc" style="white-space: nowrap;">—</div>
+        <div class="kpi-hint" id="kpiEcPpm" style="font-size:0.7rem;color:#999;margin-top:2px;">—</div>
       </div>
       <div class="kpi kpi-temp">
         <div class="kpi-label">Temp (°C)</div>

--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -24,6 +24,7 @@
 
   const kpiPh   = document.getElementById('kpiPh');
   const kpiEc   = document.getElementById('kpiEc');
+  const kpiEcPpm = document.getElementById('kpiEcPpm');
   const kpiTemp = document.getElementById('kpiTemp');
 
   let trendChart = new Chart(chartEl, {
@@ -418,7 +419,13 @@
     // KPIs (scaled EC)
     const last = arr => (arr && arr.length ? arr[arr.length-1].y : null);
     if (typeof kpiPh   !== 'undefined') kpiPh.textContent   = last(ph)   != null ? Number(last(ph)).toFixed(2) : '—';
-    if (typeof kpiEc   !== 'undefined') kpiEc.textContent   = last(ec)   != null ? Number(last(ec)).toFixed(2) : '—';
+    if (typeof kpiEc   !== 'undefined') {
+      const ecVal = last(ec);
+      kpiEc.textContent = ecVal != null ? Number(ecVal).toFixed(2) : '—';
+      if (typeof kpiEcPpm !== 'undefined' && ecVal != null) {
+        kpiEcPpm.textContent = `(≈ ${Math.round(ecVal * 500)} ppm @500)`;
+      }
+    }
     if (typeof kpiTemp !== 'undefined') kpiTemp.textContent = last(temp) != null ? Number(last(temp)).toFixed(1) : '—';
     const ecLbl = document.querySelector('.kpi-ec .kpi-label');
     if (ecLbl) ecLbl.textContent = 'EC (mS/cm)';


### PR DESCRIPTION
## Summary

Ensures EC units are unambiguous and consistent across the UI without changing any backend code.

## Changes
- Added ppm hint below EC value in Overview KPI card: ( XXX ppm @500)
- Added tooltip to EC label explaining mS/cm storage and ppm @500 scale
- No conversion applied to primary EC display (shows raw mS/cm from API)
- Confirmed ec.js already uses correct *500 conversion for EC tab ppm display
- Added white-space: nowrap to prevent EC value wrapping

## Files Modified
- pp/static/index.html - Added ppm hint element and tooltip
- pp/static/js/trends.js - Populate ppm hint based on EC value

## Testing
- [x] Verified raw EC from API is 348.4 mS/cm
- [x] Confirmed no double conversion in existing code
- [x] Visual check: EC label shows both mS/cm and ppm hint